### PR TITLE
fix(facebook); pass on facebook error message

### DIFF
--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -27,7 +27,6 @@ module.exports = function(server, options) {
     AccessToken = Model.app.models.AccessToken;
     return AccessToken.findForRequest(req, function(err, accessToken) {
       if (err) {
-        Account.app.logger.error(err);
         return callback(err);
       }
       if (!accessToken) {

--- a/lib/facebook/index.js
+++ b/lib/facebook/index.js
@@ -37,6 +37,10 @@ module.exports = function(server, options) {
         return callback(err);
       }
       if (res.statusCode !== 200) {
+        if (accessToken && accessToken instanceof Object && accessToken.error) {
+          accessToken.error.status = 500;
+          return callback(accessToken.error);
+        }
         err = new Error(accessToken);
         err.status = 500;
         debug(JSON.stringify(err));
@@ -62,6 +66,10 @@ module.exports = function(server, options) {
         return callback(err);
       }
       if (res.statusCode !== 200) {
+        if (profile && profile instanceof Object && profile.error) {
+          profile.error.status = 500;
+          return callback(profile.error);
+        }
         err = new Error(profile);
         err.status = 500;
         debug(JSON.stringify(err));

--- a/lib/facebook/index.js
+++ b/lib/facebook/index.js
@@ -41,7 +41,7 @@ module.exports = function(server, options) {
           accessToken.error.status = 500;
           return callback(accessToken.error);
         }
-        err = new Error(accessToken);
+        err = new Error(JSON.stringify(accessToken));
         err.status = 500;
         debug(JSON.stringify(err));
         return callback(err);
@@ -70,7 +70,7 @@ module.exports = function(server, options) {
           profile.error.status = 500;
           return callback(profile.error);
         }
-        err = new Error(profile);
+        err = new Error(JSON.stringify(profile));
         err.status = 500;
         debug(JSON.stringify(err));
         return callback(err);

--- a/lib/google/index.js
+++ b/lib/google/index.js
@@ -26,11 +26,22 @@ module.exports = function(server, options) {
         grant_type: 'authorization_code'
       },
       json: true
-    }, function(err, res, token) {
+    }, function(err, res, accessToken) {
       if (err) {
+        debug(JSON.stringify(err));
         return callback(err);
       }
-      return callback(null, token.access_token);
+      if (res.statusCode !== 200) {
+        if (accessToken && accessToken instanceof Object && accessToken.error) {
+          accessToken.error.status = 500;
+          return callback(accessToken.error);
+        }
+        err = new Error(JSON.stringify(accessToken));
+        err.status = 500;
+        debug(JSON.stringify(err));
+        return callback(err);
+      }
+      return callback(null, accessToken.access_token);
     });
   };
   fetchProfile = function(accessToken, callback) {
@@ -43,6 +54,17 @@ module.exports = function(server, options) {
       json: true
     }, function(err, res, profile) {
       if (err) {
+        debug(JSON.stringify(err));
+        return callback(err);
+      }
+      if (res.statusCode !== 200) {
+        if (profile && profile instanceof Object && profile.error) {
+          profile.error.status = 500;
+          return callback(profile.error);
+        }
+        err = new Error(JSON.stringify(profile));
+        err.status = 500;
+        debug(JSON.stringify(err));
         return callback(err);
       }
       return callback(null, profile);

--- a/lib/twitter/index.js
+++ b/lib/twitter/index.js
@@ -43,6 +43,13 @@ module.exports = function(server, options) {
       }
     }, function(err, res, accessToken) {
       if (err) {
+        debug(JSON.stringify(err));
+        return callback(err);
+      }
+      if (res.statusCode !== 200) {
+        err = new Error(accessToken);
+        err.status = 500;
+        debug(JSON.stringify(err));
         return callback(err);
       }
       return callback(null, qs.parse(accessToken));
@@ -60,6 +67,13 @@ module.exports = function(server, options) {
       json: true
     }, function(err, res, profile) {
       if (err) {
+        debug(JSON.stringify(err));
+        return callback(err);
+      }
+      if (res.statusCode !== 200) {
+        err = new Error(JSON.stringify(profile));
+        err.status = 500;
+        debug(JSON.stringify(err));
         return callback(err);
       }
       return callback(null, profile);

--- a/source/common/index.coffee
+++ b/source/common/index.coffee
@@ -18,7 +18,6 @@ module.exports = (server, options) ->
     AccessToken = Model.app.models.AccessToken
     AccessToken.findForRequest req, (err, accessToken) ->
       if err
-        Account.app.logger.error err
         return callback err
       return callback null, false if not accessToken
       Model.findById accessToken.userId, callback

--- a/source/facebook/index.coffee
+++ b/source/facebook/index.coffee
@@ -31,7 +31,7 @@ module.exports = (server, options) ->
         if accessToken && accessToken instanceof Object && accessToken.error
           accessToken.error.status = 500
           return callback accessToken.error  
-        err = new Error accessToken
+        err = new Error JSON.stringify accessToken
         err.status = 500
         debug JSON.stringify err
         return callback err
@@ -53,7 +53,7 @@ module.exports = (server, options) ->
         if profile && profile instanceof Object && profile.error
           profile.error.status = 500
           return callback profile.error  
-        err = new Error profile
+        err = new Error JSON.stringify profile
         err.status = 500
         debug JSON.stringify err
         return callback err

--- a/source/facebook/index.coffee
+++ b/source/facebook/index.coffee
@@ -28,7 +28,7 @@ module.exports = (server, options) ->
         debug JSON.stringify err
         return callback err
       if res.statusCode isnt 200
-        if accessToken && accessToken instanceof Object && accessToken.error
+        if accessToken and accessToken instanceof Object and accessToken.error
           accessToken.error.status = 500
           return callback accessToken.error  
         err = new Error JSON.stringify accessToken
@@ -50,7 +50,7 @@ module.exports = (server, options) ->
         debug JSON.stringify err
         return callback err
       if res.statusCode isnt 200
-        if profile && profile instanceof Object && profile.error
+        if profile and profile instanceof Object and profile.error
           profile.error.status = 500
           return callback profile.error  
         err = new Error JSON.stringify profile

--- a/source/facebook/index.coffee
+++ b/source/facebook/index.coffee
@@ -28,6 +28,9 @@ module.exports = (server, options) ->
         debug JSON.stringify err
         return callback err
       if res.statusCode isnt 200
+        if accessToken && accessToken instanceof Object && accessToken.error
+          accessToken.error.status = 500
+          return callback accessToken.error  
         err = new Error accessToken
         err.status = 500
         debug JSON.stringify err
@@ -47,6 +50,9 @@ module.exports = (server, options) ->
         debug JSON.stringify err
         return callback err
       if res.statusCode isnt 200
+        if profile && profile instanceof Object && profile.error
+          profile.error.status = 500
+          return callback profile.error  
         err = new Error profile
         err.status = 500
         debug JSON.stringify err

--- a/source/twitter/index.coffee
+++ b/source/twitter/index.coffee
@@ -33,7 +33,14 @@ module.exports = (server, options) ->
         token: oauthToken
         verifier: oauthVerifier
     , (err, res, accessToken) ->
-      return callback err if err
+      if err
+        debug JSON.stringify err
+        return callback err
+      if res.statusCode isnt 200
+        err = new Error accessToken
+        err.status = 500
+        debug JSON.stringify err
+        return callback err
       callback null, qs.parse accessToken
 
   fetchProfile = (accessToken, callback) ->
@@ -46,7 +53,14 @@ module.exports = (server, options) ->
         oauth_token: accessToken.oauth_token
       json: true
     , (err, res, profile) ->
-      return callback err if err
+      if err
+        debug JSON.stringify err
+        return callback err
+      if res.statusCode isnt 200
+        err = new Error JSON.stringify profile
+        err.status = 500
+        debug JSON.stringify err
+        return callback err
       callback null, profile
 
   link = (req, profile, callback) ->


### PR DESCRIPTION
current error callback using new Error accessToken doens't work well when accessToken  is an object. output: {name: "Error", status: 500, message: "[object Object]",…}. not helpfull :( 

proposed change yields:
{"error":{"status":500,"message":"(#100) Tried accessing nonexisting field (nname) on node type (User)","type":"OAuthException","code":100,"fbtrace_id":"HK0ICcRDPh/"}}
better ;)

alternative to the pull request:
err = if err then err else ( if accessToken && accessToken instanceof Object && accessToken.error then  accessToken.error else null )
